### PR TITLE
[feat]: 오늘 날짜 표시 및 주말 버튼 텍스트 색상 변경 (#5)

### DIFF
--- a/src/SimpleCalendar.java
+++ b/src/SimpleCalendar.java
@@ -198,7 +198,7 @@ public class SimpleCalendar extends JFrame {
       bt_days[k].setHorizontalAlignment(SwingConstants.RIGHT);
       bt_days[k].setVerticalAlignment(SwingConstants.TOP);
       if (k % 7 == 0 || k % 7 == 6) bt_days[k].setForeground(
-          new Color(0, 0, 130)
+          new Color(0, 0, 190)
         );
 
       // 현재 달일 때의 조건


### PR DESCRIPTION
프로그램 내 캘린더에서 오늘을 확인할 수 있도록 현재 일자에 해당하는
버튼에 `핀 아이콘`이 추가될 수 있도록 하였고, 프로그램 내 가독성
향상을 위해 주말에 해당하는 버튼 텍스트는 푸른색으로 색상을 지정하였습니다.

- 수정 전

<img width="998" alt="스크린샷 2022-10-31 오후 10 22 16" src="https://user-images.githubusercontent.com/56868605/199017781-feed149a-0819-4a52-9932-643227ab7724.png">

- 수정 후

<img width="995" alt="스크린샷 2022-10-31 오후 9 51 02" src="https://user-images.githubusercontent.com/56868605/199017866-55bc52e8-f5c6-4a6e-9e81-e1d8ae5187b4.png">