### PR TITLE
[feat]: 일정 프레임 내 수행 여부 칼럼 데이터 표현 UI 변경 (#46)

### DIFF
--- a/src/ScheduleEventFrame.java
+++ b/src/ScheduleEventFrame.java
@@ -97,7 +97,14 @@ class ScheduleEvent_panel extends JPanel {
     bt_deleteSchedule = new JButton("삭제");
     bt_modifySchedule = new JButton("수정");
 
-    model = new DefaultTableModel(contents, header);
+    model =
+      new DefaultTableModel(contents, header) {
+        @Override
+        public Class<?> getColumnClass(int column) {
+          return getValueAt(0, column).getClass();
+        }
+      };
+
     DefaultTableCellRenderer celAlignCenter = new DefaultTableCellRenderer();
     celAlignCenter.setHorizontalAlignment(JLabel.CENTER);
     DefaultTableCellRenderer celAlignLeft = new DefaultTableCellRenderer();
@@ -294,7 +301,7 @@ class ScheduleEvent_panel extends JPanel {
       for (k = 0; result.next(); k++) {
         contents[k][0] = (k + 1); // 테스크 순서 번호( 1 ~ result.next()까지 )
         contents[k][1] = result.getString(1); // 태스크 내용
-        contents[k][2] = result.getString(2); // 태스크 수행 여부
+        contents[k][2] = Boolean.parseBoolean(result.getString(2)); // 태스크 수행 여부
         contents[k][3] = result.getString(3); // scheduleEvent_id (PK, 기본키)
       }
     } catch (Exception error) {


### PR DESCRIPTION
## 👀 이슈

resolve #46 

## 📌 개요

기존 일정 프레임 내에 수행 여부 칼럼에 표현되는 데이터들은 전부 문자열로
나타났지만, 좀 더 직관적인 UI를 사용하고자 checkbox 기능이 작동되도록
기능을 수정하였습니다.

## 👩‍💻 작업 사항

- 캘린더 내의 특정 일자 버튼 클릭 시 생성되는 일정 프레임 창 내부의 `수행 여부`
칼럼 내에 표현되는 데이터가 checkbox 형식으로 표현됩니다.

## ✅ 참고 사항

- 기존 UI

<img width="350" alt="스크린샷 2022-11-28 오후 5 08 56" src="https://user-images.githubusercontent.com/56868605/204229316-2f39606f-7573-4d40-a99d-d34fce6163d3.png">

- 추가 후 UI

<img width="462" alt="스크린샷 2022-11-28 오후 5 27 10" src="https://user-images.githubusercontent.com/56868605/204229452-ab65c389-bdf4-456e-ab11-6092055b1e31.png">