### PR TITLE
[bug]: 캘린더 내 등록된 일정 수 표시 버그 수정 (#50)

### DIFF
--- a/src/CalendarFrame.java
+++ b/src/CalendarFrame.java
@@ -38,7 +38,7 @@ class Calendar_panel extends JPanel {
   private int currentYear, currentMonth, currentDay, nowMonth;
   private static int user_id;
 
-  private boolean flag = false;
+  private boolean flag = false, flag2 = false;
 
   private String query, date[];
 
@@ -519,10 +519,11 @@ class Calendar_panel extends JPanel {
       int tempMonth = month - 1;
       int tempYear = year;
       int z = 0;
+      flag2 = false;
       for (k = 0; result.next(); k++) {
-        System.out.println("\n\n엥?: " + result.getString(1));
+        System.out.println("\n\n(DB): " + result.getString(1));
         date = result.getString(1).split("-");
-        System.out.println("Entered: " + tempMonth);
+        System.out.println("Entered month: " + tempMonth);
         // 년도 필터
         if (
           tempYear - Integer.parseInt(date[0]) > 1 ||
@@ -582,11 +583,31 @@ class Calendar_panel extends JPanel {
           }
 
           if (selectedDay.equals("01")) {
+            if (flag2 == true) {
+              tempMonth--;
+              flag = false;
+            }
             tempMonth++;
             if (tempMonth == 13) {
               tempYear++;
               tempMonth = 1;
             }
+          }
+
+          System.out.println("수정된 날짜 확인: " + tempMonth);
+
+          // selectedDay가 1로 시작하는데, 만약 이전 달 1일에 등록된 일정이 있다면,
+          // 현재 보고 있는 달 1일의 태스크 수가 나타나지 않는 문제가 있었음.
+          if (
+            z == 0 &&
+            Integer.parseInt(selectedDay) == 1 &&
+            Integer.parseInt(date[2]) == 1 &&
+            tempMonth - Integer.parseInt(date[1]) == 1
+          ) {
+            System.out.println("에잉...??");
+            flag2 = true;
+            z = 0;
+            break;
           }
 
           if (tempMonth == 0) {
@@ -639,7 +660,9 @@ class Calendar_panel extends JPanel {
             Integer.parseInt(date[1]) == tempMonth &&
             Integer.parseInt(date[2]) == Integer.parseInt(selectedDay)
           ) {
-            System.out.println("설정함");
+            System.out.println(
+              "eiugherighweioughweriuoghweoiughwerouihgrewiuoghwe"
+            );
             bt_days[z].setText(
                 bt_days[z].getText() + " (" + result.getString(2) + ")"
               );


### PR DESCRIPTION
## 👀 이슈

resolve #50 

## 📌 개요

기존에 작성된 코드에 의하여 캘린더 화면 내에서 일자 버튼이
1일부터 시작하고, 그 전달의 1일에 DB에 등록된 일정이 있을 때
현재 달 1일의 태스크 목록이 정상적으로 나타나지 않는 버그가
발견되어 수정하고자 하였습니다.

## 👩‍💻 작업 사항

- **`LoginFrame.java`** 파일 수정

## ✅ 참고 사항