### PR TITLE
[bug]:데이터 갱신 시 태스크 수 반영 기능 재작업

### DIFF
--- a/src/ApprovedScheduleEventFrame.java
+++ b/src/ApprovedScheduleEventFrame.java
@@ -202,7 +202,8 @@ class ApprovedScheduleEvent_panel extends JPanel {
           System.out.print("사유 : " + error.getMessage());
         }
         tf_scheduleContent.setText("");
-      } else if (e.getSource() == bt_deleteSchedule) {
+      }
+      else if (e.getSource() == bt_deleteSchedule) {
         row = table.getSelectedRow();
         if (row == -1) {
           JOptionPane.showMessageDialog(
@@ -249,7 +250,8 @@ class ApprovedScheduleEvent_panel extends JPanel {
           System.out.println("DB 쿼리 실행 실패");
           System.out.print("사유 : " + error.getMessage());
         }
-      } else if (e.getSource() == bt_modifySchedule) {
+      }
+      else if (e.getSource() == bt_modifySchedule) {
         row = table.getSelectedRow();
         if (row == -1) {
           JOptionPane.showMessageDialog(
@@ -302,10 +304,14 @@ class ApprovedScheduleEvent_panel extends JPanel {
           System.out.print("사유 : " + error.getMessage());
         }
       }
-      for (int i = 0; i < 42; i++) {
+      for (int i = 0; i < 42; i++){
         String str = Calendar_panel.bt_days[i].getText();
-        if (str.endsWith(")")) {
-          Calendar_panel.bt_days[i].setText(str.substring(0, str.length() - 4));
+        if(str != null && str.endsWith(")")) {
+          while(!str.endsWith("(")){
+            str = str.substring(0, str.length()-1);
+          }
+          str = str.substring(0, str.length()-2);
+          Calendar_panel.bt_days[i].setText(str);
         }
       }
       Calendar_panel.setScheduledEventCnt();

--- a/src/NonApprovedScheduleEventFrame.java
+++ b/src/NonApprovedScheduleEventFrame.java
@@ -281,10 +281,14 @@ class NonApprovedScheduleEvent_panel extends JPanel {
           System.out.print("사유 : " + error.getMessage());
         }
       }
-      for (int i = 0; i < 42; i++) {
+      for (int i = 0; i < 42; i++){
         String str = Calendar_panel.bt_days[i].getText();
-        if (str.endsWith(")")) {
-          Calendar_panel.bt_days[i].setText(str.substring(0, str.length() - 4));
+        if(str != null && str.endsWith(")")) {
+          while(!str.endsWith("(")){
+            str = str.substring(0, str.length()-1);
+          }
+          str = str.substring(0, str.length()-2);
+          Calendar_panel.bt_days[i].setText(str);
         }
       }
       Calendar_panel.setScheduledEventCnt();


### PR DESCRIPTION
## 👀 이슈

resolve #57 

## 📌 개요

권한 분리로 인해 일정 추가 이벤트가 둘로 나뉘어 기존의 데이터 갱신 시 실시간으로 캘린더에 반영되던 것이 정상작동하지 않아 문제가 발생하였다.

## 👩‍💻 작업 사항

승인/미승인 일정추가 이벤트의 기존 코드를 수정하여 데이터 갱신 시 변경점이 캘린더에 바로 반영될 수 있도록 하였다.

## ✅ 참고 사항

수정 전
![image](https://user-images.githubusercontent.com/74577654/205437473-31776a11-ef5b-44e9-bf1b-beec35e0d247.png)

수정 후
![image](https://user-images.githubusercontent.com/74577654/205437460-0ef1bf23-8950-425e-8d53-cf2a8a475e19.png)

