### PR TITLE
[feat]: 서버 데이터베이스 및 테이블 명 변경에 따른 쿼리문 수정 (#61)

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="lib" path="lib/mysql-connector-java-8.0.29.jar"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>group-calendar-application</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/src/ApprovedScheduleEventFrame.java
+++ b/src/ApprovedScheduleEventFrame.java
@@ -193,7 +193,7 @@ class ApprovedScheduleEvent_panel extends JPanel {
         }
 
         query =
-          "INSERT INTO `simple_calendar`.`scheduleEvent` (`group_id`, `content`, `modify_time`, `completed`, `approved`) VALUES (" +
+          "INSERT INTO `group_calendar`.`scheduleEvent` (`group_id`, `content`, `modify_time`, `completed`, `approved`) VALUES (" +
           group_id +
           ", '" +
           tf_scheduleContent.getText() +
@@ -235,7 +235,7 @@ class ApprovedScheduleEvent_panel extends JPanel {
         if (!checkIsAdmin()) return;
 
         query =
-          "DELETE FROM `simple_calendar`.`scheduleEvent` WHERE (`scheduleEvent_id` = " +
+          "DELETE FROM `group_calendar`.`scheduleEvent` WHERE (`scheduleEvent_id` = " +
           contents[row][4] +
           ")";
         System.out.println(query);
@@ -291,7 +291,7 @@ class ApprovedScheduleEvent_panel extends JPanel {
         // 미승인 일정 탭에서 승인 여부 체크 시 현재 권한이 어드민인지 확인
 
         query =
-          "UPDATE `simple_calendar`.`scheduleEvent` SET `content` = '" +
+          "UPDATE `group_calendar`.`scheduleEvent` SET `content` = '" +
           table.getValueAt(row, 1) +
           "', `completed` = '" +
           table.getValueAt(row, 2) +
@@ -351,7 +351,7 @@ class ApprovedScheduleEvent_panel extends JPanel {
   void updatingtableData() {
     try {
       query =
-        "select count(*) from simple_calendar.scheduleEvent where group_id = " +
+        "select count(*) from group_calendar.scheduleEvent where group_id = " +
         group_id +
         " AND modify_time LIKE '" +
         year +
@@ -367,7 +367,7 @@ class ApprovedScheduleEvent_panel extends JPanel {
       peopleCnt = Integer.parseInt(result.getString(1));
       contents = new Object[peopleCnt][5];
       query =
-        "SELECT content, completed, approved, scheduleEvent_id FROM simple_calendar.scheduleEvent WHERE group_id = " +
+        "SELECT content, completed, approved, scheduleEvent_id FROM group_calendar.scheduleEvent WHERE group_id = " +
         group_id +
         " AND modify_time LIKE '" +
         year +

--- a/src/BookmarkFrame.java
+++ b/src/BookmarkFrame.java
@@ -177,7 +177,7 @@ class Bookmark_panel extends JPanel {
           return;
         }
         query =
-          "INSERT INTO `simple_calendar`.`bookmark` (`group_id`, `title`, `url`) VALUES (" +
+          "INSERT INTO `group_calendar`.`bookmark` (`group_id`, `title`, `url`) VALUES (" +
           group_id +
           ", '" +
           tf_title.getText() +
@@ -209,7 +209,7 @@ class Bookmark_panel extends JPanel {
           return;
         }
         query =
-          "DELETE FROM `simple_calendar`.`bookmark` WHERE (`bookmark_id` = " +
+          "DELETE FROM `group_calendar`.`bookmark` WHERE (`bookmark_id` = " +
           contents[row][3] +
           ")";
         System.out.println(query);
@@ -253,7 +253,7 @@ class Bookmark_panel extends JPanel {
         }
 
         query =
-          "UPDATE simple_calendar.bookmark SET title = '" +
+          "UPDATE group_calendar.bookmark SET title = '" +
           table.getValueAt(row, 1) +
           "', url = '" +
           table.getValueAt(row, 2) +
@@ -299,7 +299,7 @@ class Bookmark_panel extends JPanel {
   void updatingtableData() {
     try {
       query =
-        "select count(*) from simple_calendar.bookmark where group_id = " +
+        "select count(*) from group_calendar.bookmark where group_id = " +
         group_id;
 
       System.out.println(query);
@@ -309,7 +309,7 @@ class Bookmark_panel extends JPanel {
       contents = new Object[peopleCnt][4];
 
       query =
-        "SELECT title, url, bookmark_id FROM simple_calendar.bookmark WHERE group_id = " +
+        "SELECT title, url, bookmark_id FROM group_calendar.bookmark WHERE group_id = " +
         group_id;
       System.out.println(query);
       result = dbc.selectData(query);

--- a/src/CalendarFrame.java
+++ b/src/CalendarFrame.java
@@ -278,7 +278,7 @@ class Calendar_panel extends JPanel {
               // bt_temp.requestFocus();
               // tf_scheduleContent.setText("새로운 이벤트");
               // tf_scheduleContent.requestFocus(true);
-              // INSERT INTO `simple_calendar`.`scheduleEvent` (`scheduleEvent_id`, `group_id`, `content`, `date`, `completed`) VALUES ('1', '125', '안농~~', '2022-11-01', 'true');
+              // INSERT INTO `group_calendar`.`scheduleEvent` (`scheduleEvent_id`, `group_id`, `content`, `date`, `completed`) VALUES ('1', '125', '안농~~', '2022-11-01', 'true');
             }
           }
         );
@@ -541,7 +541,7 @@ class Calendar_panel extends JPanel {
   public static void setScheduledEventCnt() {
     System.out.println("---------------------------------------------------");
     query =
-      "select modify_time, count(scheduleEvent_id) from simple_calendar.scheduleEvent where group_id = " +
+      "select modify_time, count(scheduleEvent_id) from group_calendar.scheduleEvent where group_id = " +
       group_id +
       " group by (modify_time) order by (modify_time)";
     try {

--- a/src/GetAdminRoleFrame.java
+++ b/src/GetAdminRoleFrame.java
@@ -75,7 +75,7 @@ class GetAdminRoleFrame extends JFrame {
     public void actionPerformed(ActionEvent e) {
       if (e.getSource() == bt_getAdminRole) {
         query =
-          "select * from simple_calendar.user where group_id = " +
+          "select * from group_calendar.group where group_id = " +
           group_id +
           " AND adminPassword LIKE '" +
           tf_adminPassword.getText() +

--- a/src/LoginFrame.java
+++ b/src/LoginFrame.java
@@ -73,7 +73,7 @@ class LoginFrame extends JFrame {
     public void actionPerformed(ActionEvent e) {
       if (e.getSource() == bt_signIn) {
         query =
-          "SELECT * FROM simple_calendar.user where groupId LIKE '" +
+          "SELECT * FROM group_calendar.group where groupId LIKE '" +
           tf_groupId.getText() +
           "' AND password LIKE '" +
           pf_pw.getText() +

--- a/src/NonApprovedScheduleEventFrame.java
+++ b/src/NonApprovedScheduleEventFrame.java
@@ -184,7 +184,7 @@ class NonApprovedScheduleEvent_panel extends JPanel {
         }
 
         query =
-          "INSERT INTO `simple_calendar`.`scheduleEvent` (`group_id`, `content`, `modify_time`, `completed`, `approved`) VALUES (" +
+          "INSERT INTO `group_calendar`.`scheduleEvent` (`group_id`, `content`, `modify_time`, `completed`, `approved`) VALUES (" +
           group_id +
           ", '" +
           tf_scheduleContent.getText() +
@@ -220,7 +220,7 @@ class NonApprovedScheduleEvent_panel extends JPanel {
           return;
         }
         query =
-          "DELETE FROM `simple_calendar`.`scheduleEvent` WHERE (`scheduleEvent_id` = " +
+          "DELETE FROM `group_calendar`.`scheduleEvent` WHERE (`scheduleEvent_id` = " +
           contents[row][4] +
           ")";
         System.out.println(query);
@@ -270,7 +270,7 @@ class NonApprovedScheduleEvent_panel extends JPanel {
         }
 
         query =
-          "UPDATE `simple_calendar`.`scheduleEvent` SET `content` = '" +
+          "UPDATE `group_calendar`.`scheduleEvent` SET `content` = '" +
           table.getValueAt(row, 1) +
           "', `completed` = '" +
           table.getValueAt(row, 2) +
@@ -326,7 +326,7 @@ class NonApprovedScheduleEvent_panel extends JPanel {
   void updatingtableData() {
     try {
       query =
-        "select count(*) from simple_calendar.scheduleEvent where group_id = " +
+        "select count(*) from group_calendar.scheduleEvent where group_id = " +
         group_id +
         " AND modify_time LIKE '" +
         year +
@@ -342,7 +342,7 @@ class NonApprovedScheduleEvent_panel extends JPanel {
       peopleCnt = Integer.parseInt(result.getString(1));
       contents = new Object[peopleCnt][5];
       query =
-        "SELECT content, completed, approved, scheduleEvent_id FROM simple_calendar.scheduleEvent WHERE group_id = " +
+        "SELECT content, completed, approved, scheduleEvent_id FROM group_calendar.scheduleEvent WHERE group_id = " +
         group_id +
         " AND modify_time LIKE '" +
         year +

--- a/src/SignUpFrame.java
+++ b/src/SignUpFrame.java
@@ -98,9 +98,10 @@ public class SignUpFrame extends JFrame {
 
     public void actionPerformed(ActionEvent e) {
       query =
-        "select count(*) from simple_calendar.user where groupId like '" +
+        "select count(*) from group_calendar.group where groupId like '" +
         tf_groupId.getText() +
         "'";
+        System.out.println(query);
       if (e.getSource() == bt_idConfirm) {
         if (tf_groupId.getText().equals("")) {
           JOptionPane.showMessageDialog(
@@ -191,7 +192,7 @@ public class SignUpFrame extends JFrame {
 
         try {
           query =
-            "INSERT INTO simple_calendar.user (groupId, password, adminPassword, groupName) VALUES ('" +
+            "INSERT INTO group_calendar.group (groupId, password, adminPassword, groupName) VALUES ('" +
             tf_groupId.getText() +
             "', '" +
             pf_pw.getText() +


### PR DESCRIPTION
## 👀 이슈

resolve #61

## 📌 개요

프로젝트 관련 기존 로컬 서버 환경에서 원격 접속이 가능한
외부 서버로 DB가 변경됨에 따라 코드 내 특정 쿼리문을
수정된 사항에 알맞게 변경하였습니다.

## 👩‍💻 작업 사항

- 프로젝트 자바 코드 내 simple_calendar가 포함된 쿼리문을 group_calendar로 수정함.
- 프로젝트 자바 코드 내 테이블명이 user였던 쿼리문을 group으로 수정함.

## ✅ 참고 사항

- 기존 DB 구성

![Screenshot 2022-12-14 at 1 02 47 AM](https://user-images.githubusercontent.com/56868605/207383092-2efe3b22-a265-4a48-a38a-6599f028d759.png)

- 수정 후 DB 구성

![Screenshot 2022-12-14 at 1 03 12 AM](https://user-images.githubusercontent.com/56868605/207383164-e070e7cd-b0df-40af-a7f4-0f9991dcb70d.png)